### PR TITLE
Resolves basetypes issue of #8 by allowing basetypes with zero occupancy

### DIFF
--- a/smarty/sampler.py
+++ b/smarty/sampler.py
@@ -94,6 +94,10 @@ class AtomTypeSampler(object):
         self.decorators = AtomTyper.read_typelist(decorators_filename)
         self.replacements = AtomTyper.read_typelist(replacements_filename)
 
+        # Store a copy of the basetypes, as these (and only these) are allowed 
+        # to end up with zero occupancy
+        self.basetypes = copy.deepcopy(self.atomtypes)
+
         # Store a deep copy of the molecules since they will be annotated
         self.molecules = copy.deepcopy(molecules)
 
@@ -317,8 +321,8 @@ class AtomTypeSampler(object):
                     valid_proposal = False
                     # Store this atomtype to speed up future rejections
                     self.atomtypes_with_no_matches.add(proposed_atomtype)
-                # Reject if parent type is now unused.
-                if (proposed_atom_typecounts[atomtype_typename] == 0):
+                # Reject if parent type is now unused, UNLESS it is a base type
+                if (proposed_atom_typecounts[atomtype_typename] == 0) and (atomtype_typename not in self.basetypes):
                     # Reject because new type is unused in dataset.
                     if self.verbose: print("Parent type '%s' (%s) now unused in dataset; rejecting." % (atomtype, atomtype_typename))
                     valid_proposal = False

--- a/smarty/sampler.py
+++ b/smarty/sampler.py
@@ -82,10 +82,6 @@ class AtomTypeSampler(object):
         -----
         This is just a proof of concept.  No scoring of molecular properties is performed.
 
-        TODO
-        ----
-        * Maintain a list of types that do not type any molecules so that we can avoid proposing these again.
-
         """
 
         self.verbose = verbose

--- a/smarty/sampler.py
+++ b/smarty/sampler.py
@@ -97,6 +97,8 @@ class AtomTypeSampler(object):
         # Store a copy of the basetypes, as these (and only these) are allowed 
         # to end up with zero occupancy
         self.basetypes = copy.deepcopy(self.atomtypes)
+        # Store smarts for basetypes
+        self.basetypes_smarts = [ smarts for (smarts, name) in self.basetypes ]
 
         # Store a deep copy of the molecules since they will be annotated
         self.molecules = copy.deepcopy(molecules)
@@ -322,7 +324,7 @@ class AtomTypeSampler(object):
                     # Store this atomtype to speed up future rejections
                     self.atomtypes_with_no_matches.add(proposed_atomtype)
                 # Reject if parent type is now unused, UNLESS it is a base type
-                if (proposed_atom_typecounts[atomtype_typename] == 0) and (atomtype_typename not in self.basetypes):
+                if (proposed_atom_typecounts[atomtype_typename] == 0) and (atomtype not in self.basetypes_smarts):
                     # Reject because new type is unused in dataset.
                     if self.verbose: print("Parent type '%s' (%s) now unused in dataset; rejecting." % (atomtype, atomtype_typename))
                     valid_proposal = False


### PR DESCRIPTION
This resolves the hierarchy issue discussed in #8 by allowing creation of derivative types that make the base types (and **only** the base types) match zero atoms. As discussed in #8, the goal we believe ought to be to find specialized atom types that cover all cases in the set, leaving the base types empty. 

This does NOT yet fix the AlkEthOH example so that it recovers the `H1`, `H2`, and `H3` types because of deficiencies in how descriptors are created/sampled ( #12 ) which we think will be fixed in part by allowing binary operations such as in #13 .

This PR also brings in a very minor fix to a doc string. 
