### PR TITLE
adding parent dictionary and output of hierarchy tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/smarty/sampler.py
+++ b/smarty/sampler.py
@@ -108,12 +108,6 @@ class AtomTypeSampler(object):
         # Store smarts for basetypes
         self.basetypes_smarts = [ smarts for (smarts, name) in self.basetypes ]
 
-        # Creat dictionary to store children of initial atom types
-        self.parents = dict()
-        for [smarts, name] in self.atomtypes:
-            #store empty list of chlidren for each atomtype
-            self.parents[smarts] = [] 
-
         # Ensure all base types are in initial types (and add if not) as 
         # base types are generics (such as elemental) and need to be present 
         # at the start
@@ -127,6 +121,12 @@ class AtomTypeSampler(object):
         # need never be used ever and can be deleted- i.e. if we have no 
         # phosphorous in the set we don't need a phosphorous base type)
         self.used_basetypes = []
+
+        # Creat dictionary to store children of initial atom types
+        self.parents = dict()
+        for [smarts, typename] in self.atomtypes:
+            #store empty list of chlidren for each atomtype
+            self.parents[smarts] = [] 
 
         # Store a deep copy of the molecules since they will be annotated
         self.molecules = copy.deepcopy(molecules)
@@ -571,6 +571,13 @@ class AtomTypeSampler(object):
             index += 1
         return output
 
+    def print_parent_tree(self):
+        """
+        Prints the hierarchy of atomtypes stored in self.parents
+        """
+        # This will need to be modified, but I want to see it printing something while testing
+        print(self.parents)
+
     def run(self, niterations, trajFile=None):
         """
         Run atomtype sampler for the specified number of iterations.
@@ -620,6 +627,8 @@ class AtomTypeSampler(object):
             start = ['Iteration,Index,Smarts,ParNum,ParentParNum,RefType,Matches,Molecules,FractionMatched,Denominator\n']
             f.writelines(start + self.traj)
             f.close()
+
+        if self.verbose: self.print_parent_tree()
 
         #Compute final type stats
         [atom_typecounts, molecule_typecounts] = self.compute_type_statistics(self.atomtypes, self.molecules)

--- a/smarty/sampler.py
+++ b/smarty/sampler.py
@@ -108,6 +108,12 @@ class AtomTypeSampler(object):
         # Store smarts for basetypes
         self.basetypes_smarts = [ smarts for (smarts, name) in self.basetypes ]
 
+        # Creat dictionary to store children of initial atom types
+        self.parents = dict()
+        for [smarts, name] in self.atomtypes:
+            #store empty list of chlidren for each atomtype
+            self.parents[smarts] = [] 
+
         # Ensure all base types are in initial types (and add if not) as 
         # base types are generics (such as elemental) and need to be present 
         # at the start
@@ -311,6 +317,7 @@ class AtomTypeSampler(object):
         # Copy current atomtypes for proposal.
         proposed_atomtypes = copy.deepcopy(self.atomtypes)
         proposed_molecules = copy.deepcopy(self.molecules)
+        proposed_parents = copy.deepcopy(self.parents)
         natomtypes = len(proposed_atomtypes)
         ndecorators = len(self.decorators)
 
@@ -329,6 +336,15 @@ class AtomTypeSampler(object):
 
             # Delete the atomtype.
             proposed_atomtypes.remove([atomtype, typename])
+
+            # update proposed parent dictionary
+            for parent, children in proposed_parents.items():
+                if atomtype in children:
+                    children += proposed_parents[atomtype]
+                    children.remove(atomtype)
+
+            del proposed_parents[atomtype]
+
             # Try to type all molecules.
             try:
                 self.type_molecules(proposed_atomtypes, proposed_molecules)
@@ -349,6 +365,10 @@ class AtomTypeSampler(object):
             proposed_atomtype = '[' + result.groups(1)[0] + '&' + decorator + ']'
             proposed_typename = atomtype_typename + ' ' + decorator_typename
             if self.verbose: print("Attempting to create new subtype: '%s' (%s) + '%s' (%s) -> '%s' (%s)" % (atomtype, atomtype_typename, decorator, decorator_typename, proposed_atomtype, proposed_typename))
+
+            # Update proposed parent dictionary
+            proposed_parents[atomtype].append(proposed_atomtype)
+            proposed_parents[proposed_atomtype] = []
 
             # Check that we haven't already determined this atom type isn't matched in the dataset.
             if proposed_atomtype in self.atomtypes_with_no_matches:
@@ -421,6 +441,7 @@ class AtomTypeSampler(object):
         if accept:
             self.atomtypes = proposed_atomtypes
             self.molecules = proposed_molecules
+            self.parents = proposed_parents
             self.atom_type_matches = proposed_atom_type_matches
             self.total_atom_type_matches = proposed_total_atom_type_matches
             return True

--- a/smarty/sampler.py
+++ b/smarty/sampler.py
@@ -571,12 +571,19 @@ class AtomTypeSampler(object):
             index += 1
         return output
 
-    def print_parent_tree(self):
+    def print_parent_tree(self, roots, start=''):
         """
-        Prints the hierarchy of atomtypes stored in self.parents
+        Recursively prints the parent tree. 
+
+        Parameters
+        ----------
+        roots = list of smarts strings to print
         """
-        # This will need to be modified, but I want to see it printing something while testing
-        print(self.parents)
+        for r in roots:
+            print("%s%s" % (start, r))
+            if r in self.parents.keys():
+                self.print_parent_tree(self.parents[r], start+'\t')
+
 
     def run(self, niterations, trajFile=None):
         """
@@ -628,9 +635,19 @@ class AtomTypeSampler(object):
             f.writelines(start + self.traj)
             f.close()
 
-        if self.verbose: self.print_parent_tree()
-
         #Compute final type stats
         [atom_typecounts, molecule_typecounts] = self.compute_type_statistics(self.atomtypes, self.molecules)
         fraction_matched_atoms = self.show_type_matches(self.atom_type_matches)
+
+        # If verbose print parent tree:
+        if self.verbose: 
+            roots = self.parents.keys()
+            # Remove keys from roots if they are children
+            for parent, children in self.parents.items():
+                for child in children:
+                    if child in roots:
+                        roots.remove(child)
+
+            print("Atom type hierarchy:")
+            self.print_parent_tree(roots, '\t')
         return fraction_matched_atoms


### PR DESCRIPTION
Adds "parent" dictionary to track parents and children 

Since there are many methods that use the atom list, I decided it would be easier to introduce a dictionary since it only needs to be used in the implementation and the sample_atomtypes method. 

My next plan is to print the tree (hierarchy) at the end of a run, if it's verbose, but I haven't quite sorted the easiest way to do that yet. 

Addresses issue #34 
