### PR TITLE
Fixing bug with basetypes vs. used_basetypes

### DIFF
--- a/examples/AlkEtOH2/atomtypes/decorators.smarts
+++ b/examples/AlkEtOH2/atomtypes/decorators.smarts
@@ -1,5 +1,5 @@
 % bonded to atoms
-$(*-z) simply-bonded
+$(*-z) singly-bonded
 $(*=z) doubly-bonded
 $(*#z) triply-bonded
 $(*:z) aromatic-bond

--- a/smarty/sampler.py
+++ b/smarty/sampler.py
@@ -718,7 +718,7 @@ class AtomTypeSampler(object):
                     reference_counts[typename] = count
 
         # If all of a basetype and it's children match found atoms and reference remove from list
-        for [base_smarts, base_typename] in self.basetypes:
+        for [base_smarts, base_typename] in self.used_basetypes:
             includeBase = True
             
             # If the number of atoms matches the references are the same for basetypes and their children

--- a/smarty/sampler.py
+++ b/smarty/sampler.py
@@ -491,7 +491,6 @@ class AtomTypeSampler(object):
 
                 # Update proposed parent dictionary
                 proposed_parents[original_basetype].append([proposed_atomtype, proposed_typename])
-                print "proposed_parents: " + str(proposed_parents)
 
             proposed_parents[proposed_atomtype] = []
 
@@ -568,7 +567,6 @@ class AtomTypeSampler(object):
             self.atomtypes = proposed_atomtypes
             self.molecules = proposed_molecules
             self.parents = proposed_parents
-            print "------------ self.parents= " + str(self.parents)
             self.atom_type_matches = proposed_atom_type_matches
             self.total_atom_type_matches = proposed_total_atom_type_matches
             return True
@@ -796,6 +794,18 @@ class AtomTypeSampler(object):
                 # Compute atomtype statistics on molecules.
                 self.show_type_statistics(self.atomtypes, atom_typecounts, molecule_typecounts, atomtype_matches=self.atom_type_matches)
                 print('')
+
+                # Print parent tree as it is now.
+                roots = self.parents.keys()
+                # Remove keys from roots if they are children
+                for parent, children in self.parents.items():
+                    child_smarts = [smarts for [smarts, name] in children]
+                    for child in child_smarts:
+                        if child in roots:
+                            roots.remove(child)
+
+                print("Atom type hierarchy:")
+                self.print_parent_tree(roots, '\t')
 
         if trajFile is not None:
             # make "trajectory" file


### PR DESCRIPTION
This addresses a bug discussed in issue #56  . 

Pull request #55 introduced a method to track which elemental atom type "trees" were complete. This used the atom type list `self.basetypes` when it should have been using `self.unused_basetypes` 

This caused a key error when atoms such as chlorine were removed from the atom list, but were still in `self.basetypes`

I also fixed a typo in decorators where a single bond was described as `simply-bonded` to `singly-bonded` 

I also noticed in this log file that there is a print statement with the parent dictionary, that I imagine was helpful for testing, but shouldn't need to be there now. It uses `str(self.parents)` which is hard to look at. We could print the parent tree at every step, with the established code if we want to see it. @camizanette and @davidlmobley do you have preferences on this last point? I can add it to this update. 
