### PR TITLE
Make asSMIRKS methods deterministic and more user friendly

### DIFF
--- a/examples/chemicalEnvironments/test_environments.ipynb
+++ b/examples/chemicalEnvironments/test_environments.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false
    },
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -41,7 +41,7 @@
       "      bond: [*:1]~[*:2]\n",
       "     angle: [*:1]~[*:2]~[*:3]\n",
       "   torsion: [*:1]~[*:2]~[*:3]~[*:4]\n",
-      "  improper: [*:1]~[*:2](~[*:4])~[*:3]\n"
+      "  improper: [*:1]~[*:2](~[*:3])~[*:4]\n"
      ]
     }
    ],
@@ -56,7 +56,7 @@
     "names = ['atom','bond','angle','torsion','improper']\n",
     "\n",
     "for idx, Env in enumerate(EnvList):\n",
-    "    print(\"%10s: %s\" % (names[idx], Env.asSMIRKS(Env.atom1)))"
+    "    print(\"%10s: %s\" % (names[idx], Env.asSMIRKS()))"
    ]
   },
   {
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false
    },
@@ -135,7 +135,7 @@
      "output_type": "stream",
      "text": [
       "initially:  [*:1]~[*:2]~[*:3]~[*:4]\n",
-      "chose bond connecting [*:1] ~ [*:2]\n",
+      "chose bond connecting [*:2] ~ [*:1]\n",
       "[*:1]-[*:2]~[*:3]~[*:4] torsion after adding '-' to bond ORtypes\n",
       "[*:1]-;@[*:2]~[*:3]~[*:4] torsion after adding '@' to bond ANDtypes\n"
      ]
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
@@ -189,8 +189,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bond to atom [*:2]\n",
-      "New atom ([#6;a]) in torsion [*:1]~[*:2](~[*:3]~[*:4]):[#6;a]\n"
+      "Bond to atom [*:1]\n",
+      "New atom ([#6;a]) in torsion [*:1](:[#6;a])~[*:2]~[*:3]~[*:4]\n"
      ]
     }
    ],
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false
    },
@@ -246,7 +246,7 @@
        "False"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -259,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
@@ -268,9 +268,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[*:1](~[*:2])~[#6]~[#8]\n",
+      "[*:1](~[#6]~[#8])~[*:2]\n",
       "Cannot remove atom [#6] because it connects two atoms\n",
-      "[*:1](~[*:2])~[#6]\n"
+      "[*:1](~[#6])~[*:2]\n"
      ]
     }
    ],
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -370,19 +370,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 30,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[#6;X3:2](-[#1:1])=[#6;X3:3]-[#6;X4:4]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# define atoms for torsion\n",
     "hydrogen = [['#1'],None]\n",
@@ -394,9 +386,7 @@
     "doublebond = [['='], None]\n",
     "\n",
     "# initiate torsion\n",
-    "torsion = environment.TorsionChemicalEnvironment(hydrogen, singlebond, triC, doublebond, triC, singlebond, tetraC)\n",
-    "\n",
-    "print torsion.asSMIRKS()"
+    "torsion = environment.TorsionChemicalEnvironment(hydrogen, singlebond, triC, doublebond, triC, singlebond, tetraC)\n"
    ]
   },
   {

--- a/smarty/environment.py
+++ b/smarty/environment.py
@@ -220,7 +220,18 @@ class ChemicalEnvironment(object):
         # Create an empty graph which will store Atom objects.
         self._graph = nx.Graph()
 
-    def asSMIRKS(self, initialAtom = None, neighbors = None, smarts = False):
+    def asSMIRKS(self, smarts = False):
+        """
+        Returns a SMIRKS representation of the chemical environment
+
+        Parameters
+        -----------
+        smarts: optional, boolean
+            if True, returns a SMARTS instead of SMIRKS without index labels
+        """
+        return self._asSMIRKS(None, None, smarts)
+
+    def _asSMIRKS(self, initialAtom = None, neighbors = None, smarts = False):
         """Return a SMIRKS representation of the chemical environment.
 
         Parameters
@@ -239,6 +250,9 @@ class ChemicalEnvironment(object):
 
         if neighbors == None:
             neighbors = self._graph.neighbors(initialAtom)
+        
+        # sort neighbors to gaurentee order is constant
+        neighbors = sorted(neighbors)
 
         # initialize smirks for starting atom
         if smarts:
@@ -258,7 +272,7 @@ class ChemicalEnvironment(object):
             new_neighbors.remove(initialAtom)
 
             # Call asSMIRKS again to get the details for that atom
-            atomSMIRKS = self.asSMIRKS(neighbor, new_neighbors, smarts)
+            atomSMIRKS = self._asSMIRKS(neighbor, new_neighbors, smarts)
 
             # Use ( ) for branch atoms (all but last)
             if idx < len(neighbors) - 1:
@@ -455,7 +469,18 @@ class AtomChemicalEnvironment(ChemicalEnvironment):
         self.atom1 = self.Atom(1, AtomInfo[0], AtomInfo[1])
         self._graph.add_node(self.atom1)
 
-    def asSMARTS(self):
+    def asSMIRKS(self, smarts = False):
+        """
+        Returns a SMIRKS representation of the chemical environment
+
+        Parameters
+        -----------
+        smarts: optional, boolean
+            if True, returns a SMARTS instead of SMIRKS without index labels
+        """
+        return self._asSMIRKS(self.atom1, None, smarts)
+
+    def asAtomtypeSMARTS(self):
         """
         Makes SMARTS string for one atom
 
@@ -474,7 +499,7 @@ class AtomChemicalEnvironment(ChemicalEnvironment):
             new_neighbors.remove(self.atom1)
 
             bondSMARTS = self._graph.edge[self.atom1][neighbor]['bond'].asSMARTS()
-            neighborSMARTS = self.asSMIRKS(neighbor, new_neighbors, True)
+            neighborSMARTS = self._asSMIRKS(neighbor, new_neighbors, True)
 
             smarts += '$(*' + bondSMARTS + neighborSMARTS + ')'
 

--- a/smarty/tests/test_environments.py
+++ b/smarty/tests/test_environments.py
@@ -63,7 +63,7 @@ class TestChemicalEnvironments(TestCase):
         torsion.getBonds()
 
         # get smarts and smirks for the large torsion
-        smarts = torsion.asSMARTS()
+        smarts = torsion.asAtomtypeSMARTS()
         smirks = torsion.asSMIRKS()
         # TODO: add test that these are relevant
       


### PR DESCRIPTION
We discussed this briefly in the first environment pull request, but I never made an issue. It was a faster fix than I thought so I just created a pull request instead. 

@davidlmobley here is your initial comment:

> Doc strings need some work, i.e. the main asSMIRKS functionality in the chemical environment class leaves me confused as to what "neighbors" would mean if provided (i.e. I don't know what the recursive calls there are referring to); it's also unclear what the point of providing initialAtom would be (after writing the below, I now see that this fixes which atom occurs first in the SMIRKS string, though it doesn't make the string deterministic). To some extent doc strings may benefit from usage examples.

I have updated things with the asSMIRKS methods a bit. First, I adjusted the internal working so that the printed SMIRKS from asSMIRKS always prints the same string. While different orders would identify the same fragment, I think it is preferable for the string to be deterministic. I also created an internal method (_asSMIRKS) that does the recursive method strategy so the user will not see the `initialAtom` or `neighbors` parameters which primarily existed for the recursive use. 

I had a method asSMARTS in the Atom class that creates a string for a single atom in the form smarty uses now. For example:`[#1$(*-[#6])]` instead of `[#1]-[#6]` I've renamed this method asAtomtypeSMARTS so it's more clear what it is doing. 

@cbayly13 I don't think this would change anything you're working on, but heads up for the asAtomtypeSMARTS name change. 
