### PR TITLE
Fix order mistake in smirff99Frosst

### DIFF
--- a/utilities/convert_frosst/smirff99Frosst.ffxml
+++ b/utilities/convert_frosst/smirff99Frosst.ffxml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='ASCII'?>
 <SMIRFF version="0.1" aromaticity_model="OEAroModel_MDL">
   <!-- SMIRKS (SMIRKS Force Field) template file -->
-  <Date>Date: Aug. 23, 2016</Date>
-  <Author>D. L. Mobley, UC Irvine</Author>
+  <Date>Date: Sept. 20, 2016</Date>
+  <Author>C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, UC Irvine; D. L. Mobley, UC Irvine</Author>
+  <!-- This file is meant for processing via smarty.forcefield -->
   <!-- WARNING: AMBER functional forms drop the factor of 2 in the bond energy term, so cross-comparing this file with a corresponding .frcmod file, it will appear that the values here are twice as large as they should be. -->
   <HarmonicBondForce length_unit="angstroms" k_unit="kilocalories_per_mole/angstrom**2">
     <Bond smirks="[*:1]~[*:2]" id="b1" k="2000.0" length="4.0"/>
@@ -27,8 +28,8 @@
     <Bond smirks="[#6X3:1](~[#8X1])~[#8X1:2]" id="b20" k="1312.0" length="1.250"/>
     <Bond smirks="[#6X3:1]=[#8X1+0,#8X2+1:2]" id="b21" k="1140.0" length="1.229"/>
     <Bond smirks="[#6X3:1]:[#8X2+1:2]" id="b22" k="1140.0" length="1.28"/>
-    <Bond smirks="[#6X2:1]-[#6X4:2]" id="b23" k="700.0" length="1.468"/>
-    <Bond smirks="[#6X2:1]-[#6:2]" id="b24" k="700.0" length="1.440"/>
+    <Bond smirks="[#6X2:1]-[#6:2]" id="b23" k="700.0" length="1.440"/>
+    <Bond smirks="[#6X2:1]-[#6X4:2]" id="b24" k="700.0" length="1.468"/>
     <Bond smirks="[#6X2:1]=[#6X3:2]" id="b25" k="1098.0" length="1.35"/>
     <Bond smirks="[#6X2:1]#[#7X1:2]" id="b26" k="700.0" length="1.188"/>
     <Bond smirks="[#6X2:1]#[#6X2:2]" id="b27" k="700.0" length="1.188"/>

--- a/utilities/convert_frosst/smirffishFrcmod.parm99Frosst.txt
+++ b/utilities/convert_frosst/smirffishFrcmod.parm99Frosst.txt
@@ -69,8 +69,8 @@ BOND
 [#6X3:1]=[#8X1+0,#8X2+1:2]      570.0  1.229   parm99 carbonyl oxygen
 [#6X3:1]:[#8X2+1:2]             570.0  1.28    parm99 aromatice oxonium guess
 # bonds to Csp (alkynes, nitriles, allenes)
-[#6X2:1]-[#6X4:2]     350.0    1.468   Frosst C2-CT RHF/6-31G(d,p) opt estimated force constant
 [#6X2:1]-[#6:2]       350.0    1.440   Frosst generic
+[#6X2:1]-[#6X4:2]     350.0    1.468   Frosst C2-CT RHF/6-31G(d,p) opt estimated force constant
 [#6X2:1]=[#6X3:2]     549.0    1.35    smirff generic allene is a regular double bond
 [#6X2:1]#[#7X1:2]     350.0    1.188   Frosst C2-NL from C2-C2
 [#6X2:1]#[#6X2:2]     350.0    1.188   Frosst C2-C2 RHF/6-31G(d,p) opt estimated force constant

--- a/utilities/convert_frosst/template.ffxml
+++ b/utilities/convert_frosst/template.ffxml
@@ -3,8 +3,9 @@
 <SMIRFF version="0.1" aromaticity_model="OEAroModel_MDL">
 
 <!-- SMIRKS (SMIRKS Force Field) template file -->
-<Date>Date: Aug. 23, 2016</Date>
-<Author>D. L. Mobley, UC Irvine</Author>
+<Date>Date: Sept. 20, 2016</Date>
+  <Author>C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, UC Irvine; D. L. Mobley, UC Irvine</Author>
+  <!-- This file is meant for processing via smarty.forcefield -->
 
 <!-- WARNING: AMBER functional forms drop the factor of 2 in the bond energy term, so cross-comparing this file with a corresponding .frcmod file, it will appear that the values here are twice as large as they should be. -->
 <HarmonicBondForce length_unit="angstroms" k_unit="kilocalories_per_mole/angstrom**2">


### PR DESCRIPTION
As per https://github.com/open-forcefield-group/smirff99Frosst/issues/4, fixes an out-of-order generic in `smirff99Frosst.ffxml` and the frcmod-based source file. 

Will also move updated ffxml file to smirff99Frosst repo and trigger a new release. 
