### PR TITLE
Adding utility functions to adjust and obtain positions in an OEMol

### DIFF
--- a/smarty/tests/test_utils.py
+++ b/smarty/tests/test_utils.py
@@ -11,4 +11,8 @@ class TestUtils(TestCase):
         odds = smarty.utils.parse_odds_file('odds_files/atom_index_odds.smarts')
         odds = smarty.utils.parse_odds_file('odds_files/bond_OR_bases.smarts')
         self.assertIsNone(odds[1], msg = "Parsing odds file with no odds should give None as the second entry")
-
+    def test_positions(self):
+        """Test ability to extract and set positions."""
+        molecules = smarty.utils.read_molecules('zinc-subset-tripos.mol2.gz', verbose=False)
+        positions = smarty.utils.extractPositionsFromOEMol(molecules[0])
+        smarty.utils.setPositionsInOEMol(molecules[0], positions)

--- a/smarty/utils.py
+++ b/smarty/utils.py
@@ -29,6 +29,7 @@ from openeye.oeomega import *
 from openeye.oequacpac import *
 
 import time
+from simtk import unit
 
 #=============================================================================================
 # UTILITY ROUTINES
@@ -255,3 +256,43 @@ def parse_odds_file(filename, verbose = False):
 
     return (decorators, odds)
 
+
+def setPositionsInOEMol(molecule, positions):
+    """Set the positions in an OEMol using a position array with units from simtk.unit, i.e. from OpenMM. Atoms must have same order.
+
+    Arguments:
+    ---------
+    molecule : OEMol
+        OpenEye molecule
+    positions : Nx3 array
+        Unit-bearing via simtk.unit Nx3 array of coordinates
+    """
+    if molecule.NumAtoms() != len(positions): raise ValueError("Number of atoms in molecule does not match length of position array.")
+    pos_unitless = positions/unit.angstroms
+
+    coordlist = []
+    for idx in range(len(pos_unitless)):
+        for j in range(3):
+            coordlist.append( pos_unitless[idx][j])
+    molecule.SetCoords(OEFloatArray(coordlist))
+
+def extractPositionsFromOEMol(molecule):
+    """Get the positions from an OEMol and return in a position array with units via simtk.unit, i.e. foramtted for OpenMM.
+    Adapted from choderalab/openmoltools test function extractPositionsFromOEMOL
+
+    Arguments:
+    ----------
+    molecule : OEMol
+        OpenEye molecule
+
+    Returns:
+    --------
+    positions : Nx3 array
+        Unit-bearing via simtk.unit Nx3 array of coordinates
+    """
+
+    positions = unit.Quantity(numpy.zeros([molecule.NumAtoms(), 3], numpy.float32), unit.angstroms)
+    coords = molecule.GetCoords()
+    for index in range(molecule.NumAtoms()):
+        positions[index,:] = unit.Quantity(coords[index], unit.angstroms)
+    return positions


### PR DESCRIPTION
Adds utility functions to obtain positions (formatted for OpenMM) from an OEMol and to swap positions within an OEMol (i.e. from positions from an OpenMM simulation or minimization), as well as a corresponding test.
