### PR TITLE
Add checking that torsions end up with at least one phase.

### DIFF
--- a/smarty/forcefield.py
+++ b/smarty/forcefield.py
@@ -1550,6 +1550,9 @@ class PeriodicTorsionGenerator(object):
                     idivf = _extractQuantity(node, parent, 'idivf%d' % index)
                     self.k[-1] /= float(idivf)
                 index += 1
+            # Check for errors, i.e. 'phase' instead of 'phase1'
+            if len(self.phase)==0:
+               raise Exception("Error: Torsion with id %s has no parseable phase entries." % self.pid)
 
     class ImproperTorsionType(object):
 
@@ -1593,6 +1596,9 @@ class PeriodicTorsionGenerator(object):
                 # If it's an improper, divide by the factor of six internally
                 if node.tag=='Improper':
                     self.k[-1] /= 6.
+            # Check for errors, i.e. 'phase' instead of 'phase1'
+            if len(self.phase)==0:
+               raise Exception("Error: Torsion with id %s has no parseable phase entries." % self.pid)
 
 
     def __init__(self, forcefield):


### PR DESCRIPTION
Fix #176 by checking that all torsions contain at least one phase (preventing a silent error where a torsion with a `phase` but not a `phase1` would parse but be empty).