### PR TITLE
fix date in smirff99Frosst

### DIFF
--- a/utilities/convert_frosst/smirff99Frosst.ffxml
+++ b/utilities/convert_frosst/smirff99Frosst.ffxml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='ASCII'?>
 <SMIRFF version="0.1" aromaticity_model="OEAroModel_MDL">
   <!-- SMIRKS (SMIRKS Force Field) template file -->
-  <Date>Date: Nov. 7, 2016</Date>
+  <Date>Date: Mar. 3, 2017</Date>
   <Author>C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, UC Irvine; D. L. Mobley, UC Irvine</Author>
   <!-- This file is meant for processing via smarty.forcefield -->
   <!-- WARNING: AMBER functional forms drop the factor of 2 in the bond energy term, so cross-comparing this file with a corresponding .frcmod file, it will appear that the values here are twice as large as they should be. -->

--- a/utilities/convert_frosst/smirffishFrcmod.parm99Frosst.txt
+++ b/utilities/convert_frosst/smirffishFrcmod.parm99Frosst.txt
@@ -2,6 +2,7 @@
 # Date: Tue Aug 25 2016
 # Author: C. I. Bayly, OpenEye Scientific Software
 #
+# Updated: Many times during Fall 2016 - Winter 2017, most recently Fri. March 3, 2017
 
 NONBON
 [*:1]   4.  0.25  smirff dummy_generic  a really big soft atom


### PR DESCRIPTION
As @davidlmobley pointed out we didn't update the date in smirff99Frosst.ffxml with the last pull request. 

I added a comment to the smirffishFrcmod that looked like it was created in August with no note about updates. 