### PR TITLE
Correct checking for divide by zero risk when parsing "trajectory" file in score_utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All tools for implementation of the SMIRNOFF in OpenMM have been moved to the [o
 * `devtools/` - continuous integration and packaging scripts and utilities
 * `oe_license.txt.enc` - encrypted OpenEye license for continuous integration testing
 * `.travis.yml` - travis-ci continuous integration file
-* `utilities/` - some utility functionality relating to the project.
+* `utilities/` - some utility functionality relating to the project, specifically testing the speed of ChemicalEnvironments for sampling in SMIRKY.
 
 ## Prerequisites
 

--- a/smarty/score_utils.py
+++ b/smarty/score_utils.py
@@ -63,12 +63,12 @@ def load_trajectory( trajFile):
                     timeseries[iteration][reftype][k] = data_dict[k][linenr]
                 else:
                     timeseries[iteration][reftype][k.lower()] = data_dict[k][linenr]
-            try:
-                den = float(timeseries[iteration][reftype][denominator])
-                timeseries[iteration][reftype]['fraction'] = timeseries[iteration][reftype][numerator]/den
-            except ZeroDivisionError:
+            den = float(timeseries[iteration][reftype][denominator])
+            if den == 0.0:
                 print("At iteration %s, found %s matched atoms and a denominator of %s for reftype %s..." % (iteration, timeseries[iteration][reftype][numerator], timeseries[iteration][reftype][denominator], reftype))
-                raise
+                timeseries[iteration][reftype]['fraction'] = numpy.nan
+            else:
+                timeseries[iteration][reftype]['fraction'] = timeseries[iteration][reftype][numerator]/den
 
     return timeseries
 


### PR DESCRIPTION
I am making a PR so we can determine why the nightly tests are failing. I made a small change to a line in the README so github would let me make a PR, but it isn't that important.