### PR TITLE
Change open-forcefield-group to openforcefield

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - pip install --pre -i https://pypi.anaconda.org/openeye/label/beta/simple openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Install openforcefield tools
   # TODO if changes to openforcefield become less dynamic switch to conda install?
-  - pip install git+https://github.com/open-forcefield-group/openforcefield.git
+  - pip install git+https://github.com/openforcefield/openforcefield.git
   # Build the recipe
   - conda build devtools/conda-recipe
   # Install

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Options:
 
 ---
 
-##smirky
+## smirky
 
 Check out examples in `examples/smirky/`:
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-[![Build Status](https://travis-ci.org/open-forcefield-group/smarty.svg?branch=master)](https://travis-ci.org/open-forcefield-group/smarty?branch=master)
+[![Build Status](https://travis-ci.org/openforcefield/smarty.svg?branch=master)](https://travis-ci.org/openforcefield/smarty?branch=master)
 [![DOI](https://zenodo.org/badge/60921138.svg)](https://zenodo.org/badge/latestdoi/60921138)
 
 # `smarty`: Exploring Bayesian atom type sampling
 
 This is a simple example of how Bayesian atom type sampling using reversible-jump Markov chain Monte Carlo (RJMCMC) [1] over SMARTS types might work.
 
-All tools for implementation of the SMIRNOFF in OpenMM have been moved to the [openforcefield repository](https://github.com/open-forcefield-group/openforcefield)
+All tools for implementation of the SMIRNOFF in OpenMM have been moved to the [openforcefield repository](https://github.com/openforcefield/openforcefield)
 
 ## Manifest
 
 * `examples/` - some toy examples - look here to get started
-* `smarty/` - simple toolkit illustrating the use of RJMCMC to sample over SMARTS-specified atom types and SMIRKS-specified bonded and non-bonded parameter types. 
+* `smarty/` - simple toolkit illustrating the use of RJMCMC to sample over SMARTS-specified atom types and SMIRKS-specified bonded and non-bonded parameter types.
 * `devtools/` - continuous integration and packaging scripts and utilities
 * `oe_license.txt.enc` - encrypted OpenEye license for continuous integration testing
 * `.travis.yml` - travis-ci continuous integration file
@@ -165,7 +165,7 @@ Currently, the acceptance criteria does not include the full Metropolis-Hastings
 
 ### Elemental Decomposition
 
-The input option `--element` allows a user to specify which atoms types to sample based on atomic number. The default input is 0 (corresponding to no specified atomic number) and will attempt to match all atom types. If an element number is given (i.e. `--element=1` for hydrogen) only atoms with that atomic number are considered. Specifying an element number does not affect any other smarty behavior.  
+The input option `--element` allows a user to specify which atoms types to sample based on atomic number. The default input is 0 (corresponding to no specified atomic number) and will attempt to match all atom types. If an element number is given (i.e. `--element=1` for hydrogen) only atoms with that atomic number are considered. Specifying an element number does not affect any other smarty behavior.
 
 Finally, here is a complete list of input options for smarty. Under `usage` all bracketed parameters are optional.
 ```
@@ -356,10 +356,10 @@ Options:
 
 ## The SMIRNOFF force field format
 
-The SMIRNOFF force field format is documented [here](https://github.com/open-forcefield-group/openforcefield/blob/master/The-SMIRNOFF-force-field-format.md). 
-It was previously avaialbe in this repository, but has been moved. 
-SMIRNOFF99Frosst, a version of SMIRNOFF mirroring the parameters found in the parm@Frosst force field, is now housed in its own [repository](https://github.com/open-forcefield-group/smirnoff99Frosst).
-`forcefield.py` and other modules required to implement the SMIRNOFF format for simulations in OpenMM have also been moved. These scripts and examples on how to use them can be found at [open-forcefield-group/openforcefield](https://github.com/open-forcefield-group/openforcefield).
+The SMIRNOFF force field format is documented [here](https://github.com/openforcefield/openforcefield/blob/master/The-SMIRNOFF-force-field-format.md).
+It was previously avaialbe in this repository, but has been moved.
+SMIRNOFF99Frosst, a version of SMIRNOFF mirroring the parameters found in the parm@Frosst force field, is now housed in its own [repository](https://github.com/openforcefield/smirnoff99Frosst).
+`forcefield.py` and other modules required to implement the SMIRNOFF format for simulations in OpenMM have also been moved. These scripts and examples on how to use them can be found at [openforcefield/openforcefield](https://github.com/openforcefield/openforcefield).
 
 ## References
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -33,5 +33,5 @@ test:
     - smarty
 
 about:
-  home: https://github.com/open-forcefield-group/smarty
+  home: https://github.com/openforcefield/smarty
   license: MIT

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 ## Manifest
 * `parm@frosst/` - example illustrating attempt to recover parm@frosst atom types
-* `smarty_simulations/` - examples to implement smarty, a tool to rediscover parm@frosst atomtypes on the AlkEthOH molecules set 
+* `smarty_simulations/` - examples to implement smarty, a tool to rediscover parm@frosst atomtypes on the AlkEthOH molecules set
 * `smirky_simulations/` - example usage of the smirky sampling tool to rediscover the SMIRNOFF99Frosst parameter types
 
-**We have rearranged the Open Force Field group if you are looking for an example that used to be here, but is no longer it can be found at [openforcefield/examples/](https://github.com/open-forcefield-group/openforcefield/tree/master/examples)** 
+**We have rearranged the Open Force Field group if you are looking for an example that used to be here, but is no longer it can be found at [openforcefield/examples/](https://github.com/openforcefield/openforcefield/tree/master/examples)**

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description = ("Automated Bayesian atomtype sampling"),
     license = "MIT",
     keywords = "Bayesian atomtype sampling forcefield parameterization",
-    url = "http://github.com/open-forcefield-group/smarty",
+    url = "http://github.com/openforcefield/smarty",
     packages=['smarty', 'smarty/tests', 'smarty/data'],
     long_description=read('README.md'),
     classifiers=[


### PR DESCRIPTION
I don't know how necessary this was, but I figured it would be good to have the links here updated to the new group name just in case. 